### PR TITLE
Replicate S3 bucket structure in Synapse and Only index new files

### DIFF
--- a/params.R
+++ b/params.R
@@ -2,10 +2,10 @@
 ## Required Parameters
 ################################
 
-INGRESS_BUCKET = 'sc-237179673806-pp-hrx2giywqix2s-s3bucket-mhb2u0tf0ift'
+INGRESS_BUCKET = 'sc-237179673806-pp-a2c32zmbbq566-s3bucket-2vq5unuhcxjo'
 # S3 bucket whose objects are being copied
 
-PRE_ETL_BUCKET = 'sc-237179673806-pp-daamam3ykuje4-s3bucket-1jslzxl1xq4zm'
+PRE_ETL_BUCKET = 'sc-237179673806-pp-lytud6mnzjczm-s3bucket-edpunhjxp7bs'
 # S3 bucket to where objects are being copied into
 
 AWS_DOWNLOAD_LOCATION = 'temp_aws'
@@ -14,5 +14,5 @@ AWS_DOWNLOAD_LOCATION = 'temp_aws'
 FILE_LIST_OUTPUT = 's3files.txt' 
 # file name of the file where the aws ls output is saved
 
-SYNAPSE_PARENT_ID = 'syn51364759'
-# Synapse location where the objects are listed
+SYNAPSE_PARENT_ID = 'syn51399136'
+# Synapse location where the S3 bucket objects are listed

--- a/synIndex.R
+++ b/synIndex.R
@@ -3,18 +3,27 @@
 ################################
 
 #############
+### Synapse credentials
+#############
+synapse_creds <- read.table('synapse_creds.txt', header = F, sep = '=', stringsAsFactors = F) 
+SYNAPSE_USERNAME <- synapse_creds$V2[1]
+SYNAPSE_PASSWORD <- synapse_creds$V2[2]
+
+#############
 # Required functions and libraries
 #############
 library(tidyverse)
 library(synapser)
+library(synapserutils)
 library(rjson)
-synapser::synLogin()
+synapser::synLogin(SYNAPSE_USERNAME, SYNAPSE_PASSWORD)
 source('awscli_utils.R')
 
 #############
-# Parameters
+# Required Parameters
 #############
 source('params.R')
+SYNAPSE_FILEVIEW_ID = 'syn51399596'
 
 #############
 # NOTE
@@ -30,39 +39,114 @@ s3lsBucketObjects(source_bucket = paste0('s3://', PRE_ETL_BUCKET,'/'),
 
 # Get bucket params
 bucket_params <- list(uploadType='S3',
-                    concreteType='org.sagebionetworks.repo.model.project.ExternalS3StorageLocationSetting',
-                    bucket=SOURCE_BUCKET)
+                      concreteType='org.sagebionetworks.repo.model.project.ExternalS3StorageLocationSetting',
+                      bucket=PRE_ETL_BUCKET)
 
 # The above list is just to verify/reference, 
 # since we will replicate the structure locally
 # we will work with that
 
-## Get a list of all local files
-localFileList <- list.files(path = AWS_DOWNLOAD_LOCATION,
-                            all.files = TRUE, # get hidden files too
-                            recursive = TRUE, # get files inside sub-folders (if any)
-                            full.names = FALSE) # to get the directory path prepended to the file name
+# all folders inside the AWS_DOWNLOAD_LOCATION
+# When we create dataFileHandleId in synapse it will create some folders in the source S3 bucket
+# we don't need those
+localDirs <- list.dirs(path = AWS_DOWNLOAD_LOCATION, full.names = FALSE) 
+
+
+## The folders we want to show in synapse
+## This would depend on the how the data is organized in the main S3 INGRESS bucket
+FOLDERS_TO_SYNC_SYNAPSE <- c('adults',
+                             'pregnant',
+                             'pediatric') 
+
+## From the local AWS location remove all folders that are not the ones selected above
+dirs_to_delete <- dplyr::setdiff(localDirs, c(FOLDERS_TO_SYNC_SYNAPSE, "")) # "" is the local directory, a result of list.dirs(.. full.names=FALSE)
+
+## delete the unwanted directories before creating a upload manifest
+for(dir_ in dirs_to_delete){
+  unlink(paste0(AWS_DOWNLOAD_LOCATION,"/",dir_), recursive = TRUE)
+}
+
+
+# localFileList <- list.files(path = AWS_DOWNLOAD_LOCATION,
+#                             all.files = TRUE, # get hidden files too
+#                             recursive = TRUE, # get files inside sub-folders (if any)
+#                             full.names = FALSE) # to get the directory path prepended to the file name
+
+#############
+# Get a manifest of files to upload
+#############
+## The S3 bucket is synced to AWS_DOWNLOAD_LOCATION locally. 
+## We will use synapse cmd line client manifest function to replicate the folder structure 
+## but NOT upload the files. We will create a datafilehandleid in place later instead of uploading file
+
+old_path <- Sys.getenv("PATH")
+Sys.setenv(PATH = paste(old_path, "/home/ubuntu/R/x86_64-pc-linux-gnu-library/3.6/PythonEmbedInR/bin", sep = ":"))
+## When we install synapser, it installs synapseclient and along with it the synapse cmd line client
+
+SYSTEM_COMMAND <- glue::glue('synapse -u "{SYNAPSE_USERNAME}" -p "{SYNAPSE_PASSWORD}" manifest --parent-id {SYNAPSE_PARENT_ID} --manifest current_manifest.tsv {AWS_DOWNLOAD_LOCATION}')
+
+## Generate manifest file
+system(SYSTEM_COMMAND)
+###########
+## Get a list of all files to upload and their synapse locations(parentId) 
+###########
+STR_LEN_AWS_DOWNLOAD_LOCATION = stringr::str_length(AWS_DOWNLOAD_LOCATION)
+
+synapse_manifest <- read.csv('current_manifest.tsv', sep = '\t', stringsAsFactors = F) %>% 
+  dplyr::filter(path != paste0(AWS_DOWNLOAD_LOCATION,'/owner.txt')) %>%  # need not create a dataFileHandleId for owner.txt
+  dplyr::rowwise() %>% 
+  dplyr::mutate(file_key = stringr::str_sub(string = path, start = STR_LEN_AWS_DOWNLOAD_LOCATION+2)) %>% # location of file from home folder of S3 bucket 
+  dplyr::ungroup()
+
+synapse_fileview <- synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$asDataFrame()
+
+
+## find those files that are not in the fileview
+synapse_manifest_to_upload <- synapse_manifest %>% 
+  dplyr::anti_join(synapse_fileview %>% 
+                     dplyr::select(parent = parentId,
+                                   file_key = dataFileKey))
+
 
 #############
 # Index in Synapse
 #############
 ## For each file index it in Synapse given a parent synapse folder
-for(file_ in localFileList){
-  print(file_)
-  absolute_file_path <- tools::file_path_as_absolute(paste0(AWS_DOWNLOAD_LOCATION,'/',file_))
-  
-  temp_syn_obj <- synapser::synCreateExternalS3FileHandle(
-    bucket_name = bucket_params$bucket,
-    s3_file_key = file_, # 
-    file_path = absolute_file_path,
-    parent = SYNAPSE_PARENT_ID
-  )
-  
-  f <- File(dataFileHandleId=temp_syn_obj$id, 
-            parentId=SYNAPSE_PARENT_ID,
-            name = temp_syn_obj$fileName) ## set file name same as the one from realpath
-  
-  f <- synStore(f)
-  
+# for(file_ in localFileList){
+#   print(file_)
+#   absolute_file_path <- tools::file_path_as_absolute(paste0(AWS_DOWNLOAD_LOCATION,'/',file_))
+#   print(absolute_file_path)
+# }
+
+if(nrow(synapse_manifest_to_upload) > 0){ # there are some files to upload
+  for(file_number in seq(nrow(synapse_manifest_to_upload))){
+    
+    # file and related synapse parent id 
+    file_= synapse_manifest_to_upload$path[file_number]
+    parent_id = synapse_manifest_to_upload$parent[file_number]
+    s3_file_key = synapse_manifest_to_upload$file_key[file_number]
+    # this would be the location of the file in the S3 bucket, in the local it is at {AWS_DOWNLOAD_LOCATION}/
+    # that is why we remove that part of the string
+    
+    # print(file_)
+    # print(parent_id)
+    
+    absolute_file_path <- tools::file_path_as_absolute(file_) # local absolute path
+    # print(absolute_file_path)
+    
+    temp_syn_obj <- synapser::synCreateExternalS3FileHandle(
+      bucket_name = bucket_params$bucket,
+      s3_file_key = s3_file_key, #
+      file_path = absolute_file_path,
+      parent = parent_id
+    )
+    
+    f <- File(dataFileHandleId=temp_syn_obj$id,
+              parentId=parent_id,
+              name = temp_syn_obj$fileName) ## set file name same as the one from realpath
+    
+    f <- synStore(f)
+    
+  }
 }
 

--- a/synIndex.R
+++ b/synIndex.R
@@ -51,7 +51,6 @@ bucket_params <- list(uploadType='S3',
 # we don't need those
 localDirs <- list.dirs(path = AWS_DOWNLOAD_LOCATION, full.names = FALSE) 
 
-
 ## The folders we want to show in synapse
 ## This would depend on the how the data is organized in the main S3 INGRESS bucket
 FOLDERS_TO_SYNC_SYNAPSE <- c('adults',
@@ -65,7 +64,6 @@ dirs_to_delete <- dplyr::setdiff(localDirs, c(FOLDERS_TO_SYNC_SYNAPSE, "")) # ""
 for(dir_ in dirs_to_delete){
   unlink(paste0(AWS_DOWNLOAD_LOCATION,"/",dir_), recursive = TRUE)
 }
-
 
 # localFileList <- list.files(path = AWS_DOWNLOAD_LOCATION,
 #                             all.files = TRUE, # get hidden files too
@@ -87,6 +85,7 @@ SYSTEM_COMMAND <- glue::glue('synapse -u "{SYNAPSE_USERNAME}" -p "{SYNAPSE_PASSW
 
 ## Generate manifest file
 system(SYSTEM_COMMAND)
+
 ###########
 ## Get a list of all files to upload and their synapse locations(parentId) 
 ###########
@@ -100,13 +99,11 @@ synapse_manifest <- read.csv('current_manifest.tsv', sep = '\t', stringsAsFactor
 
 synapse_fileview <- synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$asDataFrame()
 
-
 ## find those files that are not in the fileview
 synapse_manifest_to_upload <- synapse_manifest %>% 
   dplyr::anti_join(synapse_fileview %>% 
                      dplyr::select(parent = parentId,
                                    file_key = dataFileKey))
-
 
 #############
 # Index in Synapse

--- a/synIndex.R
+++ b/synIndex.R
@@ -34,8 +34,8 @@ SYNAPSE_FILEVIEW_ID = 'syn51399596'
 # Get bucket params and file list
 #############
 ## Get a list of all Objects in the PRE_ETL S3 bucket 
-s3lsBucketObjects(source_bucket = paste0('s3://', PRE_ETL_BUCKET,'/'),
-                  output_file = FILE_LIST_OUTPUT)
+# s3lsBucketObjects(source_bucket = paste0('s3://', PRE_ETL_BUCKET,'/'),
+#                   output_file = FILE_LIST_OUTPUT)
 
 # Get bucket params
 bucket_params <- list(uploadType='S3',

--- a/synapse_creds.txt
+++ b/synapse_creds.txt
@@ -1,0 +1,2 @@
+username="<USERNAME>"
+password="<PASSWORD>"


### PR DESCRIPTION
- Code to read in Synapse credentials from a synapse_creds.txt file
- Added code to retain only required folders in the local copy of S3 bucket (when we create a dataFileHandleId, it will create a filehandleobject, which we don't want to index again into synapse, it will be like reindexing a pointer)
- Used synapse cmd line client to generate a manifest of files and the synapse parent id of synapse location
- Using a fileview from synapse to get list of indexed files in synapse
- From above two, index only new set of files